### PR TITLE
Added missing props to type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,13 @@ declare module 'react-draggable-tags' {
         render: (arg: { tag: T; index: number }) => JSX.Element;
         onChange?: (tags: Array<T>) => void;
         isList?: boolean;
+        initialTags?: Array<T>;
+        getAddTagFunc?: Function;
+        withHotspot?: boolean;
+        style?: React.CSSProperties;
+        tagStyle?: React.CSSProperties;
+        build?: (arg: { tag: T; index: number }) => JSX.Element;
+        className?: string;
     }
 
     export class DraggableArea<T> extends React.Component<DraggableProps<T>, unknown> { }


### PR DESCRIPTION
Allows the usage of the missing props in Typescript.

Currently only the props "tags, render, onChange and isList" can be used, so e.g. withHotspot can't be used, since there is no way to exclude elements in hotspot because that depends on withHotspot being true.